### PR TITLE
Remove pin_compatible packages

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -41,13 +41,13 @@ requirements:
    - python
    - openalea.deploy
    - openalea.core
-   - {{ pin_compatible('qt', exact=True) }}
+   - qt <5 #{{ pin_compatible('qt', exact=True) }}
    - pyqt
    - gmp [unix]
    - cgal [unix]
    - qhull
    - ann
-   - {{ pin_compatible('boost', exact=True) }}
+   - boost #{{ pin_compatible('boost', exact=True) }}
    - path.py
 
 test:


### PR DESCRIPTION
This broke all installation.
The wrong boost package is selected and this take the lead to our channel.

We may use pin_compatible option later on, but on all packages.
The current solution is to upload our packages on the same channel and give priority to the channel.