### PR TITLE
Fix issue 73 on ZBufferEngine

### DIFF
--- a/src/openalea/plantgl/algo/view.py
+++ b/src/openalea/plantgl/algo/view.py
@@ -13,7 +13,7 @@ def orthoimage(scene : Scene, imgsize : tuple = (800,800), zoom : float = 1, azi
     :param elevation: The elevation (in degrees) of view to render
     :return: The resulting image
     """
-    z = ZBufferEngine(imgsize[0],imgsize[1], (255,255,255), eColorBased)
+    z = ZBufferEngine(imageWidth=imgsize[0],imageHeight=imgsize[1], backGroundColor=(255,255,255)) #, style=eColorBased) BUG the enum is not recognised...
         
     bbx = BoundingBox(scene)
     center = bbx.getCenter()
@@ -59,7 +59,7 @@ def perspectiveimage(scene : Scene, imgsize : tuple = (800,800), zoom : float = 
     :param elevation: The elevation (in degrees) of view to render
     :return: The resulting image
     """
-    z = ZBufferEngine(imgsize[0],imgsize[1], (255,255,255), eColorBased)
+    z = ZBufferEngine(imageWidth=imgsize[0],imageHeight=imgsize[1], backGroundColor=(255,255,255)) #, style=eColorBased) BUG the enum is not recognised...
         
     bbx = BoundingBox(scene)
     center = bbx.getCenter()


### PR DESCRIPTION
Fix an error in the call of ZBufferEngine: with the Python interface the enum style=eColorBased is not recognised