### PR TITLE
Macos latest

### DIFF
--- a/.github/workflows/conda-package-build.yml
+++ b/.github/workflows/conda-package-build.yml
@@ -21,5 +21,3 @@ jobs:
     uses: openalea/action-build-publish-anaconda/.github/workflows/openalea_ci.yml@main
     secrets:
       anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
-    with:
-      operating-system: '["ubuntu-latest", "windows-latest", "macos-13"]'

--- a/.github/workflows/conda-package-build.yml
+++ b/.github/workflows/conda-package-build.yml
@@ -2,9 +2,9 @@ name: OpenAlea CI
 
 on:
   push:
-    # branches:
-     # - main
-     # - master
+    branches:
+     - main
+     - master
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/conda-package-build.yml
+++ b/.github/workflows/conda-package-build.yml
@@ -2,9 +2,9 @@ name: OpenAlea CI
 
 on:
   push:
-    branches:
-      - main
-      - master
+    # branches:
+     # - main
+     # - master
     tags:
       - 'v*'
   pull_request:


### PR DESCRIPTION
PlantGL needs to work on macos-latest. GitHub will be removing support for macos-13 soon.
More information on this [post](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down)